### PR TITLE
Fix a bug in epr_core.c

### DIFF
--- a/src/epr_core.c
+++ b/src/epr_core.c
@@ -334,6 +334,7 @@ int epr_str_to_number(const char* str)
    if (strcmp(str, "*") == 0) return 1;
    if (strcmp(str, "") == 0) return 1;
 
+    errno = 0;
     l = strtol( str, &stopstring, 10 );
 
     if (errno == EDOM)


### PR DESCRIPTION
Follows discussion in http://www.brockmann-consult.de/cms/web/beam/forum/-/message_boards/message/46004
errno should be initialized to 0 before calling strtol.
