### PR TITLE
Update test file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+testdata/

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,8 +5,9 @@
 ----------------------------------------------------------------------
 Changes from Version 2.2 to Version 2.3 (of DD. MMMM YYYY)
 ----------------------------------------------------------------------
-Bugfix in epr_band.c: [EPR-7] Interpolation of geolocation ADS
-Bugfix in epr_core.c: Setting errno to 0 in method epr_str_to_number.
+1) Bugfix in epr_band.c: [EPR-7] Interpolation of geolocation ADS
+2) Bugfix in epr_core.c: Setting errno to 0 in method epr_str_to_number.
+3) Switched to a new test file.
 
 ----------------------------------------------------------------------
 Changes from Version 2.1 to Version 2.2 (of 31. July 2010)

--- a/prj/win__code_blocks/write_bands/write_bands.cbp
+++ b/prj/win__code_blocks/write_bands/write_bands.cbp
@@ -12,7 +12,7 @@
 				<Option object_output="obj\Debug\" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1 output reflec_1 reflec_4 reflec_12" />
+				<Option parameters="MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1 output reflec_1 reflec_4 reflec_12" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>
@@ -26,7 +26,7 @@
 				<Option object_output="obj\Release\" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1 output reflec_1 reflec_4 reflec_12" />
+				<Option parameters="MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1 output reflec_1 reflec_4 reflec_12" />
 				<Compiler>
 					<Add option="-O2" />
 				</Compiler>

--- a/prj/win__code_blocks/write_bitmask/write_bitmask.cbp
+++ b/prj/win__code_blocks/write_bitmask/write_bitmask.cbp
@@ -12,7 +12,7 @@
 				<Option object_output="obj\Debug\" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters='MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1 &quot;l2_flags.LAND and !l2_flags.TOAVI_BRIGHT&quot; output/bitmask.raw' />
+				<Option parameters='MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1 &quot;l2_flags.LAND and !l2_flags.TOAVI_BRIGHT&quot; output/bitmask.raw' />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>
@@ -26,7 +26,7 @@
 				<Option object_output="obj\Release\" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters='MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1 &quot;l2_flags.LAND and !l2_flags.TOAVI_BRIGHT&quot; output/bitmask.raw' />
+				<Option parameters='MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1 &quot;l2_flags.LAND and !l2_flags.TOAVI_BRIGHT&quot; output/bitmask.raw' />
 				<Compiler>
 					<Add option="-O2" />
 				</Compiler>

--- a/src/test/epr_main_test.c
+++ b/src/test/epr_main_test.c
@@ -40,7 +40,7 @@ BC_BEGIN_TEST(test_get_element_value)
 
     epr_init_api(ll, loghandler, NULL);
 
-    product_id = epr_open_product("testdata\\MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     if (product_id == NULL)
        BC_ERROR("cannot open product");
 
@@ -56,7 +56,7 @@ BC_BEGIN_TEST(test_get_element_value)
 
     field = record->fields[4];
 
-    BC_ASSERT_SAME(182, ((uint*) field->elems)[3]);
+    BC_ASSERT_SAME(93, ((uint*) field->elems)[3]);
 
     epr_free_record(record);
     epr_close_product(product_id);
@@ -96,13 +96,13 @@ EPR_SProductId* test_epr_open_product_with_missing_file(void)
 EPR_SProductId* test_epr_open_product_with_bad_api_init_flag(void) {
     EPR_SProductId* product_id = NULL;
     epr_close_api();
-    product_id = epr_open_product("testdata\\MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     return product_id;
 }
 
 EPR_SProductId* test_epr_open_product_OK(void) {
     EPR_SProductId* product_id = NULL;
-    product_id = epr_open_product("testdata\\MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     return product_id;
 }
 
@@ -153,7 +153,7 @@ BC_BEGIN_TEST(test_epr_get_dataset_id)
     BC_ASSERT_NULL(dataset_id);
 
     epr_init_api(ll, loghandler, NULL);
-    product_id = epr_open_product("testdata\\MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     if (product_id == NULL)
         BC_ERROR("cannot open product");
 
@@ -170,7 +170,7 @@ BC_BEGIN_TEST(test_epr_read_record)
     EPR_SRecord* record = NULL;
 
     epr_init_api(ll, loghandler, NULL);
-    product_id = epr_open_product("testdata\\MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     if (product_id == NULL) {
         BC_FAIL("cannot open product");
     }
@@ -431,7 +431,7 @@ BC_BEGIN_TEST(test_epr_parse_band)
     EPR_SBandId* band_id = NULL;
 
     epr_init_api(ll, epr_log_message, NULL);
-    product_id = epr_open_product("testdata/MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     band_id = epr_get_band_id(product_id, "kapusta");
     BC_ASSERT_NULL(band_id);
 
@@ -450,14 +450,14 @@ BC_BEGIN_TEST(test_tie_points_ADS_4_4)
 
     epr_init_api(ll, loghandler, NULL);
 
-    EPR_SProductId* product_id = epr_open_product("testdata/MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1");
+    EPR_SProductId* product_id = epr_open_product("testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1");
     EPR_SDatasetId* dataset_id = epr_get_dataset_id(product_id, "Tie_points_ADS");
     EPR_SRecord* record = epr_create_record(dataset_id);
     record = epr_read_record(dataset_id, 2, record);
 
     EPR_SField* field = record->fields[4];
 
-    BC_ASSERT_SAME(182,((uint*) field->elems)[3]);
+    BC_ASSERT_SAME(93,((uint*) field->elems)[3]);
 
     epr_close_product(product_id);
     epr_close_api();


### PR DESCRIPTION
The referenced test file `MER_RR__2PNMAP20080412_084905_000002422067_00365_31982_0001.N1` is not publicly available. This PR replaces it with the new file `MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1` and makes the required changes.

Currently, the new file is available as a sample here:
http://www.brockmann-consult.de/beam/data/products/MERIS/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.zip

Running `epr_main_test` produces the following output:
```
$ ./build/src/test/epr_main_test                                                              
bccunit: running test suite "main_test_suite" containing 4 test(s)
bccunit:   running test suite "test_suite_epr_api" containing 5 test(s)
bccunit:     running test case "test_get_element_value"
bccunit:     running test case "test_epr_open_product"
bccunit:     running test case "test_epr_get_dataset_id"
bccunit:     running test case "test_epr_read_record"
bccunit:     running test case "test_tie_points_ADS_4_4"
bccunit:   running test suite "test_suite_epr_core" containing 2 test(s)
bccunit:     running test case "test_epr_get_data_type_size"
bccunit:     running test case "test_epr_str_to_data_type_id"
bccunit:   running test suite "test_suite_epr_band" containing 1 test(s)
bccunit:     running test case "test_epr_parse_band"
I 2021/08/23 14:01:00 - ENVISAT Product Reader API, version 2.3
I 2021/08/23 14:01:00 - API successfully initialized
D 2021/08/23 14:01:00 - running on a little endian order architecture
D 2021/08/23 14:01:00 - product opened:
D 2021/08/23 14:01:00 - testdata/MER_RR__2PNRAL20100429_160201_000003102089_00040_42679_0001.N1
D 2021/08/23 14:01:00 - product size: 73908107
I 2021/08/23 14:01:00 - reading MPH
I 2021/08/23 14:01:00 - reading SPH
I 2021/08/23 14:01:00 - reading all DSDs
D 2021/08/23 14:01:00 - empty DSD seen (don't worry)
D 2021/08/23 14:01:00 - empty DSD seen (don't worry)
I 2021/08/23 14:01:00 - product type MER_RR__2PNRAL20100429_160201_000003102089_00040 (MERIS IODD7)
I 2021/08/23 14:01:00 - creating dataset identifiers
I 2021/08/23 14:01:00 - creating band identifiers
D 2021/08/23 14:01:00 - product scene raster size: 1121 x 1761
E 2021/08/23 14:01:00 - epr_get_band_id: band not found
bccunit:   running test suite "test_suite_epr_header" containing 1 test(s)
bccunit:     running test case "test_epr_parse_header"
W 2021/08/23 14:01:00 - product header: int integer value out of range
W 2021/08/23 14:01:00 - product header: unsigned int integer value out of range
E 2021/08/23 14:01:00 - epr_parse_header: invalid ascii header: keyword is empty
E 2021/08/23 14:01:00 - epr_parse_header: invalid ascii header: keyword not found
E 2021/08/23 14:01:00 - epr_parse_header: invalid ascii header: value not found
E 2021/08/23 14:01:00 - epr_parse_header: invalid ascii header: illegal value
E 2021/08/23 14:01:00 - epr_parse_header: invalid ascii header: illegal value
bccunit: test summary: 9 test case(s) total, 0 failure(s), 0 error(s)
```

The tests succeed, although there are some warnings and error messages printed by the API. I think they are at least partially intended by the tests as hinted by the `BC_ASSERT_NULL` invocations. Can those messages be safely ignored?