### PR TITLE
Fix several memory leaks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes from Version 2.2 to Version 2.3 (of DD. MMMM YYYY)
 1) Bugfix in epr_band.c: [EPR-7] Interpolation of geolocation ADS
 2) Bugfix in epr_core.c: Setting errno to 0 in method epr_str_to_number.
 3) Switched to a new test file.
+4) Fixed some memory leaks.
 
 ----------------------------------------------------------------------
 Changes from Version 2.1 to Version 2.2 (of 31. July 2010)

--- a/src/epr_field.c
+++ b/src/epr_field.c
@@ -162,6 +162,7 @@ EPR_SField* epr_create_field(EPR_SFieldInfo* field_info)
     data_type_size = epr_get_data_type_size(field_info->data_type_id);
     if (data_type_size == 0)
     {
+        free(field);
         epr_set_err(e_err_illegal_data_type,
                     "epr_create_field: illegal field_info data type identifier");
         return NULL;

--- a/src/epr_msph.c
+++ b/src/epr_msph.c
@@ -322,6 +322,10 @@ EPR_SRecord* epr_parse_header(const char* header_name, const char* ascii_source)
 
     epr_free_string(h_name);
 
+    if (record == NULL) {
+        epr_free_char_ptr_array(field_infos);
+    }
+
     return record;
 }
 
@@ -418,6 +422,7 @@ void epr_parse_int_token(EPR_SPtrArray* header_values, char* token_value, uint* 
             epr_set_err(e_err_invalid_value,
                         "epr_parse_header: invalid ascii header: illegal value");
             cyc ++;
+            epr_free_string(tmp);
             tmp = epr_clone_string("-999999");
             *num_bytes = sizeof(int);
             *tp = e_tid_int;

--- a/src/epr_product.c
+++ b/src/epr_product.c
@@ -79,6 +79,7 @@ EPR_SProductId* epr_open_product(const char* product_file_path) {
     epr_assign_string(&product_id->file_path, product_file_path);
 
     if (product_id->file_path == NULL) {
+        free(product_id);
         epr_set_err(e_err_out_of_memory,
                     "epr_open_product: out of memory");
         return NULL;
@@ -96,6 +97,7 @@ EPR_SProductId* epr_open_product(const char* product_file_path) {
             epr_set_err(e_err_file_access_denied,
                         "epr_open_product: file open failed");
         }
+        epr_free_product_id(product_id);
         return NULL;
     }
 

--- a/src/epr_record.c
+++ b/src/epr_record.c
@@ -341,6 +341,7 @@ EPR_SRecord* epr_create_record_from_info(EPR_SRecordInfo* record_info)
     record->fields = (EPR_SField**) calloc(record->num_fields, sizeof(EPR_SField*));
     if (record->fields == NULL)
     {
+        free(record);
         epr_set_err(e_err_out_of_memory,
                     "epr_create_record: out of memory");
         return NULL;

--- a/src/test/epr_main_test.c
+++ b/src/test/epr_main_test.c
@@ -231,18 +231,21 @@ BC_BEGIN_TEST(test_epr_parse_header)
     field = record->fields[0];
     BC_ASSERT_SAME(0, strcmp("NEGATIVE_VALUE",field->info->name));
     BC_ASSERT_SAME(-999999, ((int*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "CLOCK_STEP=+3906250000<ps>\n");
     BC_ASSERT_NOT_NULL(record);
     field = record->fields[0];
     BC_ASSERT_SAME(0, strcmp("CLOCK_STEP",field->info->name));
     BC_ASSERT_SAME(3906250000ul, ((ulong*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "SMALL_VALUES=+0000000000<bytes>\n");
     BC_ASSERT_NOT_NULL(record);
     field = record->fields[0];
     BC_ASSERT_SAME(0, strcmp("SMALL_VALUES",field->info->name));
     BC_ASSERT_SAME(0, ((ulong*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "FOR_VALUES=+00000000000189633123<10-3nm>\n");
     BC_ASSERT_NOT_NULL(record);
@@ -254,12 +257,14 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(0, strcmp("FOR_VALUES",field->info->name));
     BC_ASSERT_SAME(0, strcmp("10-3nm",field->info->unit));
     BC_ASSERT_SAME(189633123, ((uint*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "UINT32_VALUES=+000000000004294967295<bytes>\n");
     BC_ASSERT_NOT_NULL(record);
     field = record->fields[0];
     BC_ASSERT_SAME(0, strcmp("UINT32_VALUES",field->info->name));
     BC_ASSERT_SAME(4294967295ul, ((ulong*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "UINT32_VALUES=-000002147483647<bytes>\n");
     BC_ASSERT_NOT_NULL(record);
@@ -267,6 +272,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(e_tid_int,field->info->data_type_id);
     BC_ASSERT_SAME(0, strcmp("UINT32_VALUES",field->info->name));
     BC_ASSERT_SAME(-2147483647L, ((int*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "Z_Velocity=-7377.4210000<m/s>\n");
     BC_ASSERT_NOT_NULL(record);
@@ -278,6 +284,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(0, strcmp("Z_Velocity",field->info->name));
     BC_ASSERT_SAME(0, strcmp("m/s",field->info->unit));
     BC_ASSERT_SAME(-7377.421, ((double*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "STATE_VECTOR_TIME=\"20-JUN-2000 10:06:52.269120\"\n");
     BC_ASSERT_NOT_NULL(record);
@@ -289,6 +296,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(0, strcmp("STATE_VECTOR_TIME",field->info->name));
     BC_ASSERT_SAME(NULL,field->info->unit);
     BC_ASSERT_SAME(0, strcmp("20-JUN-2000 10:06:52.269120", (char*) field->elems));
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "BAND_WAVELEN=+0000412500+0000442500+0000490000+0000510000+0000560000+0000620000+0000665000+0000681250+0000705000+0000753750+0000760625+0000775000+0000865000+0000885000+0000900000<10-3nm>\n");
     BC_ASSERT_NOT_NULL(record);
@@ -306,6 +314,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(760625, ((uint*) field->elems)[10]);
     BC_ASSERT_SAME(865000, ((uint*) field->elems)[12]);
     BC_ASSERT_SAME(900000, ((uint*) field->elems)[14]);
+    epr_free_record(record);
 
       record = epr_parse_header("mph", "FOR_VALUES=+0049633000-4963300100-0049633002<10-3nm>\n");
     BC_ASSERT_NOT_NULL(record);
@@ -319,6 +328,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_NOT_SAME(-4963300100, ((uint*) field->elems)[1]);
     BC_ASSERT_SAME(-49633002, ((uint*) field->elems)[2]);
     BC_ASSERT_SAME(12,record->info->tot_size);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "DS_TYPE=A\nNUM_DSR=+00000036         \n");
     BC_ASSERT_NOT_NULL(record);
@@ -338,6 +348,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(NULL, field->info->unit);
     BC_ASSERT_SAME(36,((uint*) field->elems)[0]);
     BC_ASSERT_SAME(5,record->info->tot_size);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "=\"20-JUN-2000\"");
     BC_ASSERT_NULL(record);
@@ -353,6 +364,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(e_tid_uchar,field->info->data_type_id);
     BC_ASSERT_SAME(0,record->info->tot_size);
     BC_ASSERT_SAME(0, strcmp("X-Achse",field->info->name));
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "X-Achse=XY");
     BC_ASSERT_NOT_NULL(record);
@@ -362,6 +374,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(e_tid_int,field->info->data_type_id);
     BC_ASSERT_SAME(4,record->info->tot_size);
     BC_ASSERT_SAME(0, strcmp("X-Achse",field->info->name));
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "Y=+0+");
     BC_ASSERT_NOT_NULL(record);
@@ -373,6 +386,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(0, strcmp("Y",field->info->name));
     BC_ASSERT_SAME(NULL,field->info->unit);
     BC_ASSERT_SAME(0, ((uint*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "X-Achse=+23-4XY");
     BC_ASSERT_NOT_NULL(record);
@@ -382,6 +396,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(e_tid_int,field->info->data_type_id);
     BC_ASSERT_SAME(8,record->info->tot_size);
     BC_ASSERT_SAME(23, ((int*) field->elems)[0]);
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "X=+ 23-4");
     BC_ASSERT_NOT_NULL(record);
@@ -391,6 +406,7 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(e_tid_int,field->info->data_type_id);
     BC_ASSERT_SAME(8,record->info->tot_size);
     BC_ASSERT_SAME(0, strcmp("X",field->info->name));
+    epr_free_record(record);
 
     record = epr_parse_header("mph", "PRODUCT=\"MER_FR__2PTACR20000620_104323_00000099X000_00000_00000_0000.N1\"\nPROC_STAGE=T\nREF_DOC=\"PO-RS-MDA-GS-2009_3/B  \"\n                                        \nACQUISITION_STATION=\"ENVISAT SampleData#3\"\nPROC_TIME=\"22-FEB-2000 19:41:46.000000\"\n                                        \nPHASE=X\nREL_ORBIT=+00000\nDELTA_UT1=+.000000<s>\nX_POSITION=-7162215.231<m>\nVECTOR_SOURCE=\"00\"\nBANDWIDTH=+10001+10002+10003+10004+10005+10006<10-3nm>\nINST_FOV=+0000019151<10-6deg>\n");
     BC_ASSERT_NOT_NULL(record);
@@ -422,7 +438,6 @@ BC_BEGIN_TEST(test_epr_parse_header)
     BC_ASSERT_SAME(10001, ((uint*) field->elems)[0]);
     BC_ASSERT_SAME(10002, ((uint*) field->elems)[1]);
     BC_ASSERT_SAME(10003, ((uint*) field->elems)[2]);
-
     epr_free_record(record);
 BC_END_TEST()
 
@@ -444,6 +459,9 @@ BC_BEGIN_TEST(test_epr_parse_band)
     BC_ASSERT_SAME(1.0, epr_interpolate2D(0.0, 1.0, 0.0, 1.0, 1.0, 2.0));
     BC_ASSERT_SAME(1.5, epr_interpolate2D(0.5, 1.0, 0.0, 1.0, 1.0, 2.0));
     BC_ASSERT_SAME(2.0, epr_interpolate2D(1.0, 1.0, 0.0, 1.0, 1.0, 2.0));
+
+    epr_close_product(product_id);
+    epr_close_api();
 BC_END_TEST()
 
 BC_BEGIN_TEST(test_tie_points_ADS_4_4)
@@ -459,6 +477,7 @@ BC_BEGIN_TEST(test_tie_points_ADS_4_4)
 
     BC_ASSERT_SAME(93,((uint*) field->elems)[3]);
 
+    epr_free_record(record);
     epr_close_product(product_id);
     epr_close_api();
 BC_END_TEST()

--- a/src/test/epr_subset_test.c
+++ b/src/test/epr_subset_test.c
@@ -201,6 +201,7 @@ int main(int argc, char** argv)
         }
     }
 
+    free(buf);
     fclose(out_stream);
 
     epr_close_product(product_id);


### PR DESCRIPTION
In some cases memory is not freed correctly. Primarily this concerns error handling code that does not clean up partially initialized data structures.

I was not able to clean up all memory leaks reported by `valgrind` on the execution of `epr_main_test`, because some of the leaks are more fundamental to the design of the API than just error handling. One example is the record information, which is intentionally not freed unless it is assigned to a product. Test cases that call `epr_parse_header` directly never free the allocated memory. However, maybe this behavior can be accepted as it is covered by the high-level API.

Note: Parts of this pull request were provided by @WanzenBug.